### PR TITLE
Fix Python 2-only usage of dict.itervalues

### DIFF
--- a/pynetsnmp/twistedsnmp.py
+++ b/pynetsnmp/twistedsnmp.py
@@ -1,6 +1,5 @@
 import logging
 import struct
-import sys
 
 from ipaddr import IPAddress
 from twisted.internet import reactor

--- a/pynetsnmp/twistedsnmp.py
+++ b/pynetsnmp/twistedsnmp.py
@@ -1,6 +1,8 @@
 import logging
 import struct
 
+from six import itervalues
+
 from ipaddr import IPAddress
 from twisted.internet import reactor
 from twisted.internet.error import TimeoutError
@@ -252,7 +254,7 @@ class AgentProxy(object):
             else:
                 message = "packet dropped"
 
-            for d in (d for d, rOids in self.defers.itervalues() if not d.called):
+            for d in (d for d, rOids in itervalues(self.defers) if not d.called):
                 reactor.callLater(0, d.errback, failure.Failure(Snmpv3Error(message)))
 
             return


### PR DESCRIPTION
Replace a remaining call to `dict.itervalues` with `six.itervalues`, to retain compatibility with both Python 2 and 3.

Still trying to remain Python 2 compatible, even though I no longer see any point to it, since it is obvious that upstream is not interested in external contributions.

Closes #3