### PR TITLE
Reset self.defer at start rather than on end

### DIFF
--- a/pynetsnmp/tableretriever.py
+++ b/pynetsnmp/tableretriever.py
@@ -22,7 +22,7 @@ class TableRetriever(object):
                  limit=1000):
         self.proxy = proxy
         self.tableStatus = [_TableStatus(oid) for oid in oids]
-        self.defer = defer.Deferred()
+        self.defer = None
         if proxy.snmpVersion.find('1') > -1:
             self.how = proxy._walk
         else:
@@ -34,6 +34,7 @@ class TableRetriever(object):
         self.hit_limit = False
 
     def __call__(self):
+        self.defer = defer.Deferred()
         self.fetchSomeMore()
         return self.defer
 
@@ -52,7 +53,6 @@ class TableRetriever(object):
         for ts in self.tableStatus:
             results[ts.startOidStr]=dict([(asOidStr(oid), value) for oid, value in ts.result])
         self.defer.callback(results)
-        self.defer = None
 
     def saveResults(self, values, ts):
         if values:
@@ -75,4 +75,4 @@ class TableRetriever(object):
 
     def error(self, why):
         self.defer.errback(why)
-        self.defer = None
+


### PR DESCRIPTION
The discovery phase of an SNMPv3 transaction may cause a timeout to be generated from the call to snmp_send.  This would cause the loop in the `TableRetriever.fetchSomeMore()` to exit early, which results in `self.defer` being reset to `None` before it is returned to the caller in `TableRetriever.__call__()`.  This results in the caller not receiving a proper `Deferred` object to attach callbacks to, while the `SnmpTimeoutError` will be logged as an unhandled exception in a Deferred by the Twisted reactor.

This patch  resets `self.defer` to a new value at the start of `__call__()` instead, and never resets it back to `None`, in order for the caller to always receive a proper Deferred instance.

Fixes #4 